### PR TITLE
Update deprecated pandas date parser parameter

### DIFF
--- a/pyrsss/l1/omni.py
+++ b/pyrsss/l1/omni.py
@@ -249,7 +249,7 @@ def parse(omni_fname,
                      names=names,
                      na_values=na_values,
                      parse_dates={'date': [0, 1, 2, 3]},
-                     date_parser=lambda x: datetime.strptime(x, '%Y %j %H %M'))
+                     date_format='%Y %j %H %M')
     df.set_index('date', inplace=True)
     return df
 


### PR DESCRIPTION
This updates the deprecated pandas `date_parser` keyword to `date_format` in `pyrsss/l1/omni.py`.

The old keyword was deprecated in pandas 2.0.0 for the fixed-width reader in favor of `date_format`. No behavior change is intended; the OMNI timestamp format remains `%Y %j %H %M`.

Tested with:
- `/Users/liuyu/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile pyrsss/l1/omni.py`
- Parsed a minimal fixed-width OMNI record and confirmed the resulting datetime index and value column.